### PR TITLE
Permissions

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -5,7 +5,7 @@ provider:
     name: aws
     runtime: nodejs18.x
     stage: v1
-    region: us-east-1
+    region: ${env:AWS_REGION} # Replace with your team
 
 functions:
     app:

--- a/serverless.yml
+++ b/serverless.yml
@@ -6,12 +6,6 @@ provider:
     runtime: nodejs18.x
     stage: v1
     region: us-east-1
-    iam:
-        role:
-            statements:
-                - Effect: Allow
-                  Action: '*'
-                  Resource: '*'
 
 functions:
     app:


### PR DESCRIPTION
Lambda and API gateway can now be created on aws regions besides us-east-1 (no longer hard coded)
You must now include an additional env variable called AWS_REGION which is a string that is the desired aws region.

lambda is created with minimum required permissions to function instead of full admin access